### PR TITLE
add attorney general contact form

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,8 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="UTF-8">
+
     <!-- Facebook -->
     <meta property="og:type" content="website"/>
     <meta property="og:url" content="https://www.comcastroturf.com/"/>
@@ -18,48 +20,52 @@
     <link rel="stylesheet" type="text/css" href="main.css">
     <link rel="icon" type="image/png" href="images/favicon.png" />
   </head>
-  <body>
-  <h1 class="gradient">OPERATION<br/>COMCASTROTURF</h1>
-  <h2>Someone has submitted nearly half a million anti-net neutrality comments to the FCC, many of which appear to be completely fake — using stolen names and addresses. This needs to be investigated and stopped now.</h2>
-  <div class="search">
-    <form target="_blank" method="get" action="https://www.fcc.gov/ecfs/search/filings" accept-charset="UTF-8">
-      <input type="text" name="filers_name" placeholder="Enter your full name" title="Full Name" autocomplete="name" required>
-      <button type="submit">Search for fake comments</button>
-      <input type="hidden" name="proceedings_name" value="17-108" />
-      <input type="hidden" name="q" value="The unprecedented regulatory power the Obama Administration imposed" />
-      <input type="hidden" name="sort" value="date_disseminated,DES" />
-    </form>
-    <!--
-    <span class="then">Then:</span>
-    <button type="submit" class="second">contact Attorney General</button>
-    -->
-  </div>
 
-  <div class="social">
-    <button class="facebook">
-      <img src="images/facebook.svg" alt="Facebook" />
-      <span>Share on Facebook</span>
-    </button>
-    <button class="twitter">
-      <img src="images/twitter.svg" alt="Twitter" />
-      <span>Share on Twitter</span>
-    </button>
-  </div>
+  <body>
+    <h1 class="gradient">OPERATION<br/>COMCASTROTURF</h1>
+
+    <h2>Someone has submitted nearly half a million anti-net neutrality comments to the FCC, many of which appear to be completely fake — using stolen names and addresses. This needs to be investigated and stopped now.</h2>
+
+    <div class="search">
+      <form target="_blank" method="get" action="https://www.fcc.gov/ecfs/search/filings" accept-charset="UTF-8">
+        <input type="text" name="filers_name" placeholder="Enter your full name" title="Full Name" autocomplete="name" required>
+        <button type="submit">Search for fake comments</button>
+        <input type="hidden" name="proceedings_name" value="17-108" />
+        <input type="hidden" name="q" value="The unprecedented regulatory power the Obama Administration imposed" />
+        <input type="hidden" name="sort" value="date_disseminated,DES" />
+      </form>
+      <span class="then">Then:</span>
+      <button type="submit" class="second">contact Attorney General</button>
+    </div>
+
+    <div class="social">
+      <button class="facebook">
+        <img src="images/facebook.svg" alt="Facebook" />
+        <span>Share on Facebook</span>
+      </button>
+      <button class="twitter">
+        <img src="images/twitter.svg" alt="Twitter" />
+        <span>Share on Twitter</span>
+      </button>
+    </div>
 
     <section class="content">
       <h3>What we need you to do</h3>
       <p><strong>Everyone should check right now to see if this has happened to them.</strong> Use this form to search the FCC for comments filed in your name. It requires an exact match. If you find a fake comment filed using your name AND an address that you are currently or formerly associated with, email: <a href="mailto:team@fightforthefuture.org">team@fightforthefuture.org</a> to let us know.</p>
       <p>This search will only yield results if your name was submitted to the FCC alongside a <a href="http://www.zdnet.com/article/a-bot-is-flooding-the-fccs-website-with-fake-anti-net-neutrality-comments/">suspicious anti-net neutrality comment</a>. If you have submitted a comment to the FCC in defense of net neutrality, your comment will not show up from this search.</p>
     </section>
+
     <section>
-    <h3>What's happening</h3>
-    <p>The FCC recently set up a "Notice of Proposed Rulemaking" (NPRM) to solicit public comments on their plan to end net neutrality rules. To file a comment in the NPRM, people have to submit their name and address to a public docket. But, since the comment period began, almost half a million identical and perfectly formatted comments have been submitted to the docket, sometimes even in <a href="http://www.zdnet.com/article/a-bot-is-flooding-the-fccs-website-with-fake-anti-net-neutrality-comments/">alphabetical order</a>, in what looks like an automated "cut and copy" fashion, using the names and addresses of people from <a href="https://medium.com/@csinchok/an-analysis-of-the-anti-title-ii-bots-463f184829bc">hijacked lists</a>. People’s names and addresses are being publicly listed alongside a political message, without their permission. The comment text is associated with a non-public petition by a <a href="https://www.theverge.com/2017/5/10/15610744/anti-net-neutrality-fake-comments-identities">relatively unknown group</a>. Journalists and Internet users are helping to identify dozens of people who <a href="http://kdvr.com/2017/05/14/7000-coloradans-names-addresses-used-to-post-fake-comments-about-government-decision/">did not knowingly sign</a> the petition.</p>
+      <h3>What's happening</h3>
+      <p>The FCC recently set up a "Notice of Proposed Rulemaking" (NPRM) to solicit public comments on their plan to end net neutrality rules. To file a comment in the NPRM, people have to submit their name and address to a public docket. But, since the comment period began, almost half a million identical and perfectly formatted comments have been submitted to the docket, sometimes even in <a href="http://www.zdnet.com/article/a-bot-is-flooding-the-fccs-website-with-fake-anti-net-neutrality-comments/">alphabetical order</a>, in what looks like an automated "cut and copy" fashion, using the names and addresses of people from <a href="https://medium.com/@csinchok/an-analysis-of-the-anti-title-ii-bots-463f184829bc">hijacked lists</a>. People’s names and addresses are being publicly listed alongside a political message, without their permission. The comment text is associated with a non-public petition by a <a href="https://www.theverge.com/2017/5/10/15610744/anti-net-neutrality-fake-comments-identities">relatively unknown group</a>. Journalists and Internet users are helping to identify dozens of people who <a href="http://kdvr.com/2017/05/14/7000-coloradans-names-addresses-used-to-post-fake-comments-about-government-decision/">did not knowingly sign</a> the petition.</p>
     </section>
+
     <section>
       <h3>What we need</h3>
       <p>There is still a remote chance that some of the signatures are legitimate, or that individuals were somehow tricked into signing a comment—perhaps thinking it was in favor of net neutrality. We need to learn the extent to which these comments are fake, so we need as many as possible examples of people who are 100% sure they never signed. Once we have that, we can work with state attorney generals to track down the group committing this fraud, and figure out who funds them.</p>
       <p>If you believe a fraudulent comment was submitted on your behalf (using your name AND an address that you are currently or formerly associated with), email us: <a href="mailto:team@fightforthefuture.org">team@fightforthefuture.org</a></p>
     </section>
+
     <section>
       <h3>What we know now</h3>
       <p>We’ve been investigating these suspicious comments since we noticed them, reaching out to the real human beings across the country whose name and home address were used to file public, anti-net neutrality comments. Several people we have communicated with have confirmed that they did not give permission or sign any petition with the language in the comment.</p>
@@ -68,17 +74,46 @@
       <p>We asked the Reddit community to help us get to the bottom of all of this, too. Real human beings have been checking the FCC docket to see if their name and address (or a former address) were used to submit these fake comments and, sure enough, people from across the country are reaching out and confirming that their identity was stolen to post these comments. </p>
       <p>A <a href="http://kdvr.com/2017/05/14/7000-coloradans-names-addresses-used-to-post-fake-comments-about-government-decision/">media outlet in Denver</a> discovered that more than 7,000 such comments used names and addresses of people in Colorado, many of whom said they had never submitted such a comment when contacted by local reporters.</p>
       </section>
+
       <section>
-      <h3>Conclusion</h3>
-      <p>The more people look, <a href="https://medium.com/@csinchok/an-analysis-of-the-anti-title-ii-bots-463f184829bc">the more we find evidence</a> that nearly half a million anti-net neutrality comments in the official and public FCC docket are using real people’s stolen identities.</p>
-      <p>There is a <a href="https://news.vice.com/article/cable-companies-are-astroturfing-fake-consumer-support-to-end-net-neutrality">long</a> <a href="http://www.politico.com/story/2015/03/net-neutrality-email-american-commitment-116553">sordid</a> <a href="https://motherboard.vice.com/en_us/article/net-neutrality-is-marxist-according-to-this-koch-backed-astroturf-group">history</a> of the telecom industry funding shady “astroturf” organizations to poison the political process and do their dirty work. In 2014, telecom allies even <a href="https://www.commondreams.org/news/2015/04/01/astroturf-steroids-did-right-wing-group-fake-anti-net-neutrality-emails">submitted suspicious emails</a> to Congress. If companies like Comcast are funding this type of illegal activity, their customers and the general public deserve to know about it. If they’re not funding it, they should condemn these fake comments and tell the FCC to disregard them.</p>
+        <h3>Conclusion</h3>
+        <p>The more people look, <a href="https://medium.com/@csinchok/an-analysis-of-the-anti-title-ii-bots-463f184829bc">the more we find evidence</a> that nearly half a million anti-net neutrality comments in the official and public FCC docket are using real people’s stolen identities.</p>
+        <p>There is a <a href="https://news.vice.com/article/cable-companies-are-astroturfing-fake-consumer-support-to-end-net-neutrality">long</a> <a href="http://www.politico.com/story/2015/03/net-neutrality-email-american-commitment-116553">sordid</a> <a href="https://motherboard.vice.com/en_us/article/net-neutrality-is-marxist-according-to-this-koch-backed-astroturf-group">history</a> of the telecom industry funding shady “astroturf” organizations to poison the political process and do their dirty work. In 2014, telecom allies even <a href="https://www.commondreams.org/news/2015/04/01/astroturf-steroids-did-right-wing-group-fake-anti-net-neutrality-emails">submitted suspicious emails</a> to Congress. If companies like Comcast are funding this type of illegal activity, their customers and the general public deserve to know about it. If they’re not funding it, they should condemn these fake comments and tell the FCC to disregard them.</p>
     </section>
+
     <footer>
-    <a href="https://fftfef.org"><img src="images/fftfef.png"></a>
+      <a href="https://fftfef.org"><img src="images/fftfef.png"></a>
     </footer>
+
+    <form method="post" action="https://queue.fightforthefuture.org/action" accept-charset="UTF-8">
+      <header>
+        <h3>Tell your Attorney General to start an official investigation</h3>
+        <p>Someone is committing fraud in an attempt to influence the FCC's decision on a critical issue. If the agency has any legitimacy, it cannot move forward with its plans until this matter is resolved. State Attorney Generals have the power to get the proof we need to find out who did this and bring real pressure and hold them accountable. Sign the petition asking your Attorney General to investigate this, and demanding that the FCC reveal any information that they have about who is doing this.</p>
+      </header>
+      <main>
+        <input type="text" name="member[first_name]" placeholder="Full Name" title="Full Name" autocomplete="name" required>
+        <input type="email" name="member[email]" placeholder="Email" title="Email" required>
+        <input type="text" name="member[postcode]" placeholder="ZIP" title="ZIP" required size="5" pattern="[0-9]{5}">
+        <button type="submit">Sign</button>
+      </main>
+      <footer>
+        <p class="disclaimer">The information submitted here will be transmitted to the FCC, which may post your name and street address in a searchable database. <a href="https://www.fightforthefuture.org/" target="_blank">Fight for the Future</a> will contact you about future campaigns. <a href="https://www.fightforthefuture.org/privacy/" target="_blank">Privacy Policy</a></p>
+      </footer>
+
+      <!-- Mothership Honeypot Bot Defense -->
+      <input class="hidden" type="checkbox" checked="checked" name="hp_enabled" />
+      <input class="hidden" type="checkbox" name="hp_disabled" />
+      <input class="hidden" type="text" name="guard" />
+
+      <!-- Mothership -->
+      <input type="hidden" name="org" value="fftf"/>
+
+      <!-- Action Network -->
+      <input type="hidden" name="an_tags" value="[&quot;net-neutrality&quot;]"/>
+      <input type="hidden" name="an_petition_id" value="35c95ced-9872-43f2-8f0d-d8a9d78b4f7e"/>
+    </form>
 
     <!-- Free Progress A/B testing -->
     <script src="https://fftf.io/js/client.js" type="text/javascript"></script>
-
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
         <input type="hidden" name="sort" value="date_disseminated,DES" />
       </form>
       <span class="then">Then:</span>
-      <button class="second" id="contact-ag">Contact Attorney General</button>
+      <button class="second" id="ag-button">Contact Attorney General</button>
     </div>
 
     <div class="social">
@@ -86,38 +86,60 @@
     </footer>
 
     <section class="gutter hidden">
-      <section class="modal">
-        <a class="close" href="#">x</a>
-        <header>
-          <h3>Tell your Attorney General to start an official investigation</h3>
-          <p>Someone is committing fraud in an attempt to influence the FCC's decision on a critical issue. If the agency has any legitimacy, it cannot move forward with its plans until this matter is resolved. State Attorney Generals have the power to get the proof we need to find out who did this and bring real pressure and hold them accountable. Sign the petition asking your Attorney General to investigate this, and demanding that the FCC reveal any information that they have about who is doing this.</p>
-        </header>
-        <main>
-          <form method="post" action="https://queue.fightforthefuture.org/action" accept-charset="UTF-8">
-            <section>
-              <input type="text" name="member[first_name]" placeholder="Full Name" title="Full Name" autocomplete="name" required>
-              <input type="email" name="member[email]" placeholder="Email" title="Email" required>
-              <input type="text" name="member[postcode]" placeholder="ZIP" title="ZIP" required size="5" pattern="[0-9]{5}">
-            </section>
-            <button type="submit">Sign</button>
+    </section>
 
-            <!-- Mothership Honeypot Bot Defense -->
-            <input class="hidden" type="checkbox" checked="checked" name="hp_enabled" />
-            <input class="hidden" type="checkbox" name="hp_disabled" />
-            <input class="hidden" type="text" name="guard" />
+    <section class="modal hidden" id="ag">
+      <a class="close" href="#">x</a>
+      <header>
+        <h3>Tell your Attorney General to start an official investigation</h3>
+        <p>Someone is committing fraud in an attempt to influence the FCC's decision on a critical issue. If the agency has any legitimacy, it cannot move forward with its plans until this matter is resolved. State Attorney Generals have the power to get the proof we need to find out who did this and bring real pressure and hold them accountable. Sign the petition asking your Attorney General to investigate this, and demanding that the FCC reveal any information that they have about who is doing this.</p>
+      </header>
+      <main>
+        <form method="post" action="https://queue.fightforthefuture.org/action" accept-charset="UTF-8">
+          <section>
+            <input type="text" name="member[first_name]" placeholder="Full Name" title="Full Name" autocomplete="name" required>
+            <input type="email" name="member[email]" placeholder="Email" title="Email" required>
+            <input type="text" name="member[postcode]" placeholder="ZIP" title="ZIP" required size="5" pattern="[0-9]{5}">
+          </section>
+          <button type="submit">Sign</button>
 
-            <!-- Mothership -->
-            <input type="hidden" name="org" value="fftf"/>
+          <!-- Mothership Honeypot Bot Defense -->
+          <input class="hidden" type="checkbox" checked="checked" name="hp_enabled" />
+          <input class="hidden" type="checkbox" name="hp_disabled" />
+          <input class="hidden" type="text" name="guard" />
 
-            <!-- Action Network -->
-            <input type="hidden" name="an_tags" value="[&quot;net-neutrality&quot;]"/>
-            <input type="hidden" name="an_petition_id" value="4608f8b5-f704-4497-b9b6-da1ddedff113"/>
-          </form>
-        </main>
-        <footer>
-          <p class="disclaimer"><a href="https://www.fightforthefuture.org/" target="_blank">Fight for the Future</a> will contact you about future campaigns. <a href="https://www.fightforthefuture.org/privacy/" target="_blank">Privacy Policy</a></p>
-        </footer>
-      </section>
+          <!-- Mothership -->
+          <input type="hidden" name="org" value="fftf"/>
+
+          <!-- Action Network -->
+          <input type="hidden" name="an_tags" value="[&quot;net-neutrality&quot;]"/>
+          <input type="hidden" name="an_petition_id" value="4608f8b5-f704-4497-b9b6-da1ddedff113"/>
+        </form>
+      </main>
+      <footer>
+        <p class="disclaimer"><a href="https://www.fightforthefuture.org/" target="_blank">Fight for the Future</a> will contact you about future campaigns. <a href="https://www.fightforthefuture.org/privacy/" target="_blank">Privacy Policy</a></p>
+      </footer>
+    </section>
+
+    <section class="modal hidden" id="thanks">
+      <a class="close" href="#">x</a>
+      <header>
+        <h3>Thanks for signing!</h3>
+      </header>
+      <main>
+        <p>Thanks for signing the petition demanding state attorneys general investigate this alleged anti-net neutrality fraud at the FCC.</p>
+        <p>Now, we need as many people as possible to do the same, too. Will you share this with your friends?</p>
+      </main>
+      <footer class="social">
+        <button class="facebook">
+          <img src="images/facebook.svg" alt="Facebook" />
+          <span>Share on Facebook</span>
+        </button>
+        <button class="twitter">
+          <img src="images/twitter.svg" alt="Twitter" />
+          <span>Share on Twitter</span>
+        </button>
+      </footer>
     </section>
 
     <!-- Senty Error Reporting -->
@@ -129,49 +151,58 @@
     <script type="text/javascript">
       (function() {
         var gutter = document.querySelector('.gutter');
-        var modal = gutter.querySelector('.modal');
-        var form = modal.querySelector('form');
 
-        // Open modal
-        document.getElementById('contact-ag').addEventListener('click', function(e) {
-          e.preventDefault();
-          gutter.classList.remove('hidden');
-        });
-
-        // Close modal
-        modal.querySelector('.close').addEventListener('click', function(e) {
-          e.preventDefault();
-          gutter.classList.add('hidden');
-        });
-
-        // Close modal on escape keyup event
-        document.addEventListener('keyup', function(e) {
-          if (e.keyCode === 27) {
-            gutter.classList.add('hidden');
+        function openModal(id) {
+          // Remove any existing modal content
+          while (gutter.firstChild) {
+            gutter.removeChild(gutter.firstChild);
           }
-        });
 
-        // Replace modal with after-action thanks content
-        form.addEventListener('submit', function(e) {
-          e.preventDefault();
+          var modal = document.getElementById(id).cloneNode(true);
+          modal.classList.remove('hidden');
 
-          var xhr = new XMLHttpRequest();
-          var formData = new FormData(form);
-
-          xhr.open(form.getAttribute('method'), form.getAttribute('action'), true);
-
-          xhr.addEventListener('load', function() {
-            var header = document.createElement('h3');
-            header.innerText = 'Thanks!';
-            modal.querySelectorAll('header, main, footer').forEach(function(node) {
-              while (node.firstChild) {
-                node.removeChild(node.firstChild);
-              }
-            });
-            modal.querySelector('header').appendChild(header);
+          modal.querySelector('.close').addEventListener('click', function(e) {
+            e.preventDefault();
+            gutter.classList.add('hidden');
           });
 
-          xhr.send(formData);
+          gutter.appendChild(modal);
+          gutter.classList.remove('hidden');
+
+          return modal;
+        }
+
+        function closeModal() {
+          gutter.classList.add('hidden');
+        }
+
+        // Open modal from button
+        document.getElementById('ag-button').addEventListener('click', function(e) {
+          e.preventDefault();
+          
+          var modal = openModal('ag');
+          var form = modal.querySelector('form');
+            
+          // Display after-action thanks content
+          form.addEventListener('submit', function(e) {
+            e.preventDefault();
+
+            var xhr = new XMLHttpRequest();
+            var formData = new FormData(form);
+
+            xhr.open(form.getAttribute('method'), form.getAttribute('action'), true);
+
+            xhr.addEventListener('load', function() {
+              openModal('thanks');
+            });
+
+            xhr.send(formData);
+          });
+        });
+
+        // Close any modal on escape keyup event
+        document.addEventListener('keyup', function(e) {
+          if (e.keyCode === 27) closeModal()
         });
       })();
     </script>

--- a/index.html
+++ b/index.html
@@ -120,8 +120,11 @@
       </section>
     </section>
 
-    <!-- Free Progress A/B testing -->
-    <script src="https://fftf.io/js/client.js" type="text/javascript"></script>
+    <!-- Senty Error Reporting -->
+    <script src="https://cdn.ravenjs.com/3.15.0/raven.min.js"></script>
+    <script type="text/javascript">
+      if (typeof Raven !== 'undefined') Raven.config('https://08a03866fe184d778c454f554d296da9@sentry.io/169717').install();
+    </script>
 
     <script type="text/javascript">
       (function() {
@@ -172,5 +175,8 @@
         });
       })();
     </script>
+
+    <!-- Free Progress A/B testing -->
+    <script src="https://fftf.io/js/client.js" type="text/javascript"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
         <button type="submit">Sign</button>
       </main>
       <footer>
-        <p class="disclaimer">The information submitted here will be transmitted to the FCC, which may post your name and street address in a searchable database. <a href="https://www.fightforthefuture.org/" target="_blank">Fight for the Future</a> will contact you about future campaigns. <a href="https://www.fightforthefuture.org/privacy/" target="_blank">Privacy Policy</a></p>
+        <p class="disclaimer"><a href="https://www.fightforthefuture.org/" target="_blank">Fight for the Future</a> will contact you about future campaigns. <a href="https://www.fightforthefuture.org/privacy/" target="_blank">Privacy Policy</a></p>
       </footer>
 
       <!-- Mothership Honeypot Bot Defense -->
@@ -110,7 +110,7 @@
 
       <!-- Action Network -->
       <input type="hidden" name="an_tags" value="[&quot;net-neutrality&quot;]"/>
-      <input type="hidden" name="an_petition_id" value="35c95ced-9872-43f2-8f0d-d8a9d78b4f7e"/>
+      <input type="hidden" name="an_petition_id" value="4608f8b5-f704-4497-b9b6-da1ddedff113"/>
     </form>
 
     <!-- Free Progress A/B testing -->

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
         <input type="hidden" name="sort" value="date_disseminated,DES" />
       </form>
       <span class="then">Then:</span>
-      <button type="submit" class="second">contact Attorney General</button>
+      <button class="second" id="contact-ag">Contact Attorney General</button>
     </div>
 
     <div class="social">
@@ -85,35 +85,92 @@
       <a href="https://fftfef.org"><img src="images/fftfef.png"></a>
     </footer>
 
-    <form method="post" action="https://queue.fightforthefuture.org/action" accept-charset="UTF-8">
-      <header>
-        <h3>Tell your Attorney General to start an official investigation</h3>
-        <p>Someone is committing fraud in an attempt to influence the FCC's decision on a critical issue. If the agency has any legitimacy, it cannot move forward with its plans until this matter is resolved. State Attorney Generals have the power to get the proof we need to find out who did this and bring real pressure and hold them accountable. Sign the petition asking your Attorney General to investigate this, and demanding that the FCC reveal any information that they have about who is doing this.</p>
-      </header>
-      <main>
-        <input type="text" name="member[first_name]" placeholder="Full Name" title="Full Name" autocomplete="name" required>
-        <input type="email" name="member[email]" placeholder="Email" title="Email" required>
-        <input type="text" name="member[postcode]" placeholder="ZIP" title="ZIP" required size="5" pattern="[0-9]{5}">
-        <button type="submit">Sign</button>
-      </main>
-      <footer>
-        <p class="disclaimer"><a href="https://www.fightforthefuture.org/" target="_blank">Fight for the Future</a> will contact you about future campaigns. <a href="https://www.fightforthefuture.org/privacy/" target="_blank">Privacy Policy</a></p>
-      </footer>
+    <section class="gutter hidden">
+      <section class="modal">
+        <a class="close" href="#">x</a>
+        <header>
+          <h3>Tell your Attorney General to start an official investigation</h3>
+          <p>Someone is committing fraud in an attempt to influence the FCC's decision on a critical issue. If the agency has any legitimacy, it cannot move forward with its plans until this matter is resolved. State Attorney Generals have the power to get the proof we need to find out who did this and bring real pressure and hold them accountable. Sign the petition asking your Attorney General to investigate this, and demanding that the FCC reveal any information that they have about who is doing this.</p>
+        </header>
+        <main>
+          <form method="post" action="https://queue.fightforthefuture.org/action" accept-charset="UTF-8">
+            <section>
+              <input type="text" name="member[first_name]" placeholder="Full Name" title="Full Name" autocomplete="name" required>
+              <input type="email" name="member[email]" placeholder="Email" title="Email" required>
+              <input type="text" name="member[postcode]" placeholder="ZIP" title="ZIP" required size="5" pattern="[0-9]{5}">
+            </section>
+            <button type="submit">Sign</button>
 
-      <!-- Mothership Honeypot Bot Defense -->
-      <input class="hidden" type="checkbox" checked="checked" name="hp_enabled" />
-      <input class="hidden" type="checkbox" name="hp_disabled" />
-      <input class="hidden" type="text" name="guard" />
+            <!-- Mothership Honeypot Bot Defense -->
+            <input class="hidden" type="checkbox" checked="checked" name="hp_enabled" />
+            <input class="hidden" type="checkbox" name="hp_disabled" />
+            <input class="hidden" type="text" name="guard" />
 
-      <!-- Mothership -->
-      <input type="hidden" name="org" value="fftf"/>
+            <!-- Mothership -->
+            <input type="hidden" name="org" value="fftf"/>
 
-      <!-- Action Network -->
-      <input type="hidden" name="an_tags" value="[&quot;net-neutrality&quot;]"/>
-      <input type="hidden" name="an_petition_id" value="4608f8b5-f704-4497-b9b6-da1ddedff113"/>
-    </form>
+            <!-- Action Network -->
+            <input type="hidden" name="an_tags" value="[&quot;net-neutrality&quot;]"/>
+            <input type="hidden" name="an_petition_id" value="4608f8b5-f704-4497-b9b6-da1ddedff113"/>
+          </form>
+        </main>
+        <footer>
+          <p class="disclaimer"><a href="https://www.fightforthefuture.org/" target="_blank">Fight for the Future</a> will contact you about future campaigns. <a href="https://www.fightforthefuture.org/privacy/" target="_blank">Privacy Policy</a></p>
+        </footer>
+      </section>
+    </section>
 
     <!-- Free Progress A/B testing -->
     <script src="https://fftf.io/js/client.js" type="text/javascript"></script>
+
+    <script type="text/javascript">
+      (function() {
+        var gutter = document.querySelector('.gutter');
+        var modal = gutter.querySelector('.modal');
+        var form = modal.querySelector('form');
+
+        // Open modal
+        document.getElementById('contact-ag').addEventListener('click', function(e) {
+          e.preventDefault();
+          gutter.classList.remove('hidden');
+        });
+
+        // Close modal
+        modal.querySelector('.close').addEventListener('click', function(e) {
+          e.preventDefault();
+          gutter.classList.add('hidden');
+        });
+
+        // Close modal on escape keyup event
+        document.addEventListener('keyup', function(e) {
+          if (e.keyCode === 27) {
+            gutter.classList.add('hidden');
+          }
+        });
+
+        // Replace modal with after-action thanks content
+        form.addEventListener('submit', function(e) {
+          e.preventDefault();
+
+          var xhr = new XMLHttpRequest();
+          var formData = new FormData(form);
+
+          xhr.open(form.getAttribute('method'), form.getAttribute('action'), true);
+
+          xhr.addEventListener('load', function() {
+            var header = document.createElement('h3');
+            header.innerText = 'Thanks!';
+            modal.querySelectorAll('header, main, footer').forEach(function(node) {
+              while (node.firstChild) {
+                node.removeChild(node.firstChild);
+              }
+            });
+            modal.querySelector('header').appendChild(header);
+          });
+
+          xhr.send(formData);
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/main.css
+++ b/main.css
@@ -192,21 +192,66 @@ filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#585594', end
 	margin-top: 2px;
 }
 
-form main {
-  margin: 3em 0;
+.gutter {
+  width: 100%;
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: #171629;
+  padding: 0;
+  overflow-y: scroll;
+}
+
+.gutter .modal {
+  max-width: 840px;
+  margin: 0 auto;
+  padding: 0 20px;
+}
+
+.modal a.close {
+  position: absolute;
+  top: 1em;
+  right: 1em;
+  color: #a9a7c7;
+  text-decoration: none;
+  text-transform: uppercase;
+}
+
+.modal a.close:hover {
+  color: #fff;
+}
+
+.modal header h3 {
+  margin: 1em 0;
+}
+
+.modal main {
+  margin: 2em 0;
+}
+
+.modal form section {
+  width: 100%;
+  margin-bottom: 0.5em;
+  padding: 0;
   display: flex;
 }
 
-form main input, form main button {
-  margin: 0 10px;
+.modal input {
   flex: 1;
 }
 
-form main input[name="member[first_name]"], form main input[type="email"] {
+.modal input[name="member[first_name]"], .modal input[type="email"] {
+  margin-right: 0.5em;
   flex-grow: 2;
 }
 
-form footer {
+.modal button {
+  width: 100%;
+}
+
+.modal footer {
   padding: 0;
 }
 

--- a/main.css
+++ b/main.css
@@ -28,7 +28,6 @@ h2 {
 h3 {
 	color: #27d9ff;
 	font-size: 2em;
-	line-height: 0.2;
 }
 
 .more-info {
@@ -191,4 +190,31 @@ filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#585594', end
 	width: 500px;
 	padding: 15px;
 	margin-top: 2px;
+}
+
+form main {
+  margin: 3em 0;
+  display: flex;
+}
+
+form main input, form main button {
+  margin: 0 10px;
+  flex: 1;
+}
+
+form main input[name="member[first_name]"], form main input[type="email"] {
+  flex-grow: 2;
+}
+
+form footer {
+  padding: 0;
+}
+
+.hidden {
+  display: none;
+}
+
+.disclaimer {
+  font-size: 0.8em;
+  line-height: 1.4em;
 }


### PR DESCRIPTION
Adds a first draft of a working form (hooked up to Action Network) to the bottom of the page - do we want to wire this up to open a modal with this content when the `Contact Attorney General` button is clicked or something? I'm sure there's room for design improvements too.

<img width="826" alt="screen shot 2017-05-17 at 5 07 26 pm" src="https://cloud.githubusercontent.com/assets/1149913/26176202/569c5962-3b23-11e7-9674-6ade3068f18a.png">

/cc @labdelaziz @katro16 